### PR TITLE
State argument fixup

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "aorfanos"
 name: "pmm_admin"
-version: 1.0.0-beta1
+version: 1.0.1-beta1
 readme: "README.md"
 authors:
   - "Alexandros Orfanos <me@aorfanos.com>"

--- a/plugins/modules/pmm_admin.py
+++ b/plugins/modules/pmm_admin.py
@@ -159,7 +159,7 @@ def run_module():
         environment=dict(type="str", required=False),
         metrics_mode=dict(type="str", default="push", required=False),
         tls=dict(type="bool", required=False, default=False),
-        state=dict(type="str", required=True, default="present"),
+        state=dict(type="str", required=False, default="present"),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)


### PR DESCRIPTION
This may be due to ansible versions, but the 'required' and 'default' flags are mutually exclusive now (it can either be Required, or have a Default).

This branch makes 'state' no longer required, maintaining the 'present' default.

Thank you for the useful plugin.